### PR TITLE
 [♻️refactor]: 카카오 로그인 인가코드 서버에서 받도록 로직 변경

### DIFF
--- a/src/api/API.js
+++ b/src/api/API.js
@@ -1,6 +1,6 @@
 //import URL from "/src/api/API";
-// export const URL = `http://localhost:3000`; // => 개발용 URL
-export const URL = `https://api.trip-teller.com`; // => 배포용 URL
+export const URL = `http://localhost:3000`; // => 개발용 URL
+// export const URL = `https://api.trip-teller.com`; // => 배포용 URL
 
 export function useAPI() {
   const request = async (url, method = "GET", params = undefined) => {

--- a/src/components/units/login/LoginContent.jsx
+++ b/src/components/units/login/LoginContent.jsx
@@ -53,8 +53,8 @@ const Title = styled.div`
 const LoginContent = () => {
   const onClick = () => {
     window.Kakao.Auth.authorize({
-      // redirectUri: "http://localhost:5173/login/redirect", // 개발
-      redirectUri: "https://www.trip-teller.com/login/redirect", // 배포
+      redirectUri: "http://localhost:3000/auth/sign-in/kakao", // 개발
+      // redirectUri: "https://api.trip-teller.com/auth/sign-in/kakao", // 배포
     });
   };
 

--- a/src/pages/login/loginRedirect.jsx
+++ b/src/pages/login/loginRedirect.jsx
@@ -1,37 +1,33 @@
 import React, { useEffect } from "react";
-import { URL } from "/src/api/API";
+import { useNavigate } from "react-router-dom";
 
 const RedirectPage = () => {
-  const code = new URLSearchParams(window.location.search).get("code");
+  const navigate = useNavigate();
 
   useEffect(() => {
-    async function signInByCode() {
+    {
       try {
-        const response = await fetch(`${URL}/auth/sign-in/kakao`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-          },
-          body: JSON.stringify({ code }),
-          credentials: "include", // 쿠키 포함
-        });
-        const data = await response.json();
+        const accessToken = document.cookie
+          .split("; ")
+          .find((row) => row.startsWith("accessToken="))
+          ?.split("=")[1];
 
         // 토큰 있을 때만 localStorage에 넣어주기
-        if (data.accessToken) {
-          localStorage.setItem("accessToken", data.accessToken);
+        if (accessToken) {
+          localStorage.setItem("accessToken", accessToken);
+          document.cookie =
+            "accessToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
         } else {
-          console.log("토큰이 없어서 카카오 로그인 실패");
+          console.error("카카오 로그인 중 액세스 토큰을 찾을 수 없습니다.");
         }
-        window.location.href = "/";
       } catch (error) {
-        console.error("SignIn error:", error);
+        console.error("Kakao SignIn error:", error);
       }
     }
 
-    signInByCode();
-  }, []);
+    // 로그인 실패/성공 여부와 무관하게 메인 화면으로 리다이렉트
+    navigate("/");
+  }, [navigate]);
 
   return (
     <>

--- a/src/pages/login/loginRedirect.jsx
+++ b/src/pages/login/loginRedirect.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import "./redirectPage.css";
 
 const RedirectPage = () => {
   const navigate = useNavigate();
@@ -30,9 +31,10 @@ const RedirectPage = () => {
   }, [navigate]);
 
   return (
-    <>
-      <div>로그인 중입니다.</div>
-    </>
+    <div className="loading-container">
+      <div className="loading-bar"></div>
+      <p>로그인 중입니다...</p>
+    </div>
   );
 };
 

--- a/src/pages/login/redirectPage.css
+++ b/src/pages/login/redirectPage.css
@@ -1,0 +1,50 @@
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background-color: #f4f4f9;
+  text-align: center;
+}
+
+.loading-bar {
+  width: 80%;
+  height: 6px;
+  background-color: #ddd;
+  border-radius: 5px;
+  margin-bottom: 20px;
+  position: relative;
+}
+
+.loading-bar::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  height: 100%;
+  background-color: #3498db;
+  animation: loading 2s infinite;
+}
+
+@keyframes loading {
+  0% {
+    left: -100%;
+    width: 0%;
+  }
+  50% {
+    left: 0%;
+    width: 50%;
+  }
+  100% {
+    left: 100%;
+    width: 0%;
+  }
+}
+
+p {
+  font-size: 18px;
+  color: #333;
+  font-weight: bold;
+}


### PR DESCRIPTION
# 1. 카카오 로그인 인가코드 서버에서 받도록 로직 변경
### 변경 전 흐름 (프론트엔드 -> 서버 -> 카카오)
1. **카카오 -> 프론트엔드**: 카카오 로그인 창에서 사용자가 동의 후, 인가 코드를 쿼리 파라미터(`code`)로 전송
2. **프론트엔드 -> 서버**: 인가 코드를 `POST` 방식으로 서버에 전달 (`/sign-in/kakao`)
3. **서버 -> 카카오**: 서버는 받은 인가 코드를 카카오 서버에 전달하여 액세스 토큰 및 사용자 정보를 요청
4. **카카오 -> 서버**: 카카오는 사용자 정보를 서버로 반환
5. **서버 -> 클라이언트**: 서버는 응답으로 `accessToken`을 JSON 형태로 반환하고, `refreshToken`은 쿠키에 저장
6. **클라이언트**: 클라이언트는 `accessToken`을 로컬스토리지에 저장하여 이후 API 요청에 사용

### 변경 후 흐름 (서버 -> 카카오 -> 클라이언트)
1. **카카오 -> 서버**: 카카오 로그인 창에서 사용자가 동의 후, 인가 코드를 쿼리 파라미터(`code`)로 서버에 직접 전달
2. **서버 -> 카카오**: 서버는 받은 인가 코드를 카카오 서버에 전달하여 액세스 토큰 및 사용자 정보를 요청
3. **카카오 -> 서버**: 카카오는 사용자 정보를 서버로 반환
4. **서버 -> 클라이언트**: 서버는 응답으로 `accessToken`과 `refreshToken`을 쿠키에 저장하고, 클라이언트의 특정 페이지로 리다이렉트
5. **클라이언트**: 클라이언트는 쿠키에 저장된 `accessToken`을 로컬스토리지에 저장하여 이후 API 요청에 사용

### 참고 링크
- [카카오 로그인 공식 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#before-you-begin-process)
- [Kakao 로그인 에러 KOE303 해결방법](https://devtalk.kakao.com/t/koe303/123945/2)

![image](https://github.com/user-attachments/assets/cdf2141c-c834-4580-8e99-ea77c1e2fdbc)

---

# 2. 로딩바 CSS 추가
- 카카오 로그인 API 응답 기다리는 동안 지연되는 시간만큼 로딩바 렌더링되도록 CSS 추가
![로딩중](https://github.com/user-attachments/assets/f00ac5a7-223b-4d33-ab73-9fc6d417c30d)
